### PR TITLE
AMRNAV-6339 Enable IPC for rosbag recorder and foxglove bridge: Fix substitution error

### DIFF
--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -534,7 +534,7 @@ void FoxgloveBridge::subscribe(foxglove::ChannelId channelId, ConnectionHandle c
   try {
     auto subscriber = this->create_generic_subscription(
       topic, datatype, qos,
-      std::bind(&FoxgloveBridge::rosMessageHandler, this, channelId, clientHandle, _1),
+      static_cast<std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)>>(std::bind(&FoxgloveBridge::rosMessageHandler, this, channelId, clientHandle, _1)),
       subscriptionOptions);
     subscriptionsByClient.emplace(clientHandle, std::move(subscriber));
   } catch (const std::exception& ex) {


### PR DESCRIPTION

Changes in this PR:

- Explicitly cast callback to `std::function`

Related PRs: 
https://github.com/logivations/deep_cv/pull/7386

https://github.com/pixel-robotics/rclcpp/pull/3
https://github.com/logivations/navigation2/pull/67

Caused by backporting: https://github.com/ros2/rclcpp/pull/1928
Upstream ticket: TODO